### PR TITLE
This commit fixes a dependency problem with raspbian stretch.

### DIFF
--- a/roles/mythtv-deb/tasks/main.yml
+++ b/roles/mythtv-deb/tasks/main.yml
@@ -54,7 +54,9 @@
   set_fact:
     deb_pkg_lst:
       - '{{ deb_pkg_lst }}'
-      - libcec-dev
+      # libcec is now libcec4 
+      #- libcec-dev
+      - libcec4-dev
       - libva-dev
       - libvdpau-dev
       - libass-dev


### PR DESCRIPTION
The package libcec-dev is now named libcec4-dev.
This error was found while building dependencies on
2018-11-13-raspbian-stretch.

Signed-off-by: Patrick Menschel <menschel.p@posteo.de>