### PR TITLE
update macports playbook to allow user specified database

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ sudo port install py38-ansible
 ansible-playbook-3.8 --extra-vars=ansible_python_interpreter=/opt/local/bin/python3.8 qt5.yml --ask-become-pass
 ```
 
+MacOSX Users (optionally also specify a databse version as follows):
+```
+ansible-playbook-3.8 --extra-vars="ansible_python_interpreter=/opt/local/bin/python3.8 database_version=mariadb-10.2"  qt5.yml --ask-become-pass
+```
+
 For a buildworker system:
 ```
 sudo ansible-playbook -i hosts buildworker.yml

--- a/roles/mythtv-macports/tasks/main.yml
+++ b/roles/mythtv-macports/tasks/main.yml
@@ -2,6 +2,24 @@
 
 ---
 
+- name: specify a mariadb/mysql version to install
+  set_fact: 
+    database_version=mariadb-10.2
+  when:
+    database_version is undefined
+- name: check if this is a mariadb based install
+  set_fact:
+    database_name=mariadb
+  when: database_version is search("mariadb")
+- name: check if this is a mysql based install
+  set_fact:
+    database_name=mysql
+  when: database_version is search("mysql")
+
+- name: setup macports mariadb/mysql variant variables
+  set_fact:
+    mysql_variant="{{ database_version | regex_replace('-') | regex_replace('\.', '_') }}"
+
 - name: create a list of compilers and build essentials
   set_fact:
     macports_pkg_list:
@@ -48,6 +66,7 @@
       - libX11
       - liberation-fonts
       - dejavu-fonts
+      - '{{ database_version }}'
 
 - name: develop a Python package version suffix
   set_fact:
@@ -78,7 +97,6 @@
       - p5-date-manip
       - p5-datetime-format-iso8601
       - p5-dbi
-      - p5-dbd-mysql
       - p5-image-size
       - p5-io-socket-inet6
       - p5-json
@@ -112,27 +130,37 @@
       '{{ lookup("flattened", macports_pkg_list) }}'
     update_cache: yes
 
-- name: select the installed version of python
+- name: install p5-dbd-* for previously specified mariadb/mysql version
+  become: yes
+  become_user: root
+  become_method: sudo
+  macports:
+    name: 'p5-dbd-{{ database_name }}'
+    variant: +{{ mysql_variant }}
+
+- name: select the installed version of mariadb/mysql and python
   become: yes
   become_user: root
   become_method: sudo
   command: 'port select --set {{ item.group }} {{ item.version }}'
   with_list:
+    - { group: mysql,  version: '{{ database_version }}' }
     - { group: python,  version: 'python{{ python_package_suffix }}' }
     - { group: python3, version: 'python{{ python_package_suffix }}' }
     - { group: pip,     version: 'pip{{ python_package_suffix }}' }
     - { group: pip3,    version: 'pip{{ python_package_suffix }}' }
 
-- name: install mysqlclient (for mysqldb)
+- name: install py-mysqlclient (for mariadb/mysqldb)
   become: yes
   become_user: root
   become_method: sudo
   block:
-    - name: install mysqlclient via MacPorts (for mysqldb)
+    - name: install py-mysqlclient via MacPorts (for mariadb/mysqldb)
       macports:
         name: py{{ python_package_suffix }}-mysqlclient
+        variant: +{{ mysql_variant }}
   rescue:
-    - name: install mysqlclient via pip (for mysqldb)
+    - name: install py-mysqlclient via pip (for mariadb/mysqldb)
       pip:
         name: mysqlclient
         executable: pip3

--- a/roles/mythtv-macports/tasks/main.yml
+++ b/roles/mythtv-macports/tasks/main.yml
@@ -130,12 +130,14 @@
       '{{ lookup("flattened", macports_pkg_list) }}'
     update_cache: yes
 
-- name: install p5-dbd-* for previously specified mariadb/mysql version
+# note p5-dbd-mysql does exist, but has issues installing on some systems, 
+# p5-dbd-mariab works with mysql and has more recently been updated
+- name: install p5-dbd-mariadb for previously specified mariadb/mysql version
   become: yes
   become_user: root
   become_method: sudo
   macports:
-    name: 'p5-dbd-{{ database_name }}'
+    name: 'p5-dbd-mariadb'
     variant: +{{ mysql_variant }}
 
 - name: select the installed version of mariadb/mysql and python

--- a/roles/qt5/tasks/qt5-macports.yml
+++ b/roles/qt5/tasks/qt5-macports.yml
@@ -1,10 +1,13 @@
+# parse out database name and major/minor version
+- name: specify mysql/mariadb database version to compile against
+  set_fact:  qt_mysql_variant="{{ database_version | regex_replace('-') | regex_replace('\.', '_') }}"
+
 - name: create list of qt5 libraries
   set_fact:
     macports_pkg_list:
       - qt5
       - qt5-qtwebkit
       - qt5-qtscript
-      - qt5-mysql-plugin
   tags:
     - qt5
 
@@ -21,6 +24,16 @@
     name:
       '{{ lookup("flattened", macports_pkg_list) }}'
     update_cache: yes
+  tags:
+    - qt5
+
+- name: install qt5-mysql-plugin for previously specified mariadb/mysql version
+  become: yes
+  become_user: root
+  become_method: sudo
+  macports:
+    name: qt5-mysql-plugin
+    variant: +{{ qt_mysql_variant }}
   tags:
     - qt5
 


### PR DESCRIPTION
This update adds logic to specify mariadb-10.2 as the default database version during port install.  It also allows the user to pass in a variable specifying a different datavase version (e.g. mysql8 or mariadb-10.4) on port install.

Changes were necessary as macports was has set the default database version for support ports to different versions of mysql/mariadb.  The previous playbook would install both mysql57 and mariadb-10.2.  This update installs just one database and tells macports to install/compile the appropriate variant for all packages.

Additionally, the playbook was updated to use the p5-dbd-maridb port over p5-dbd-mysql as it is currently being better maintained.  Both are compatible with mariadb10-X and mysql57-mysql8.