### PR TITLE
Archlinux: add python-setuptools to install task

### DIFF
--- a/roles/mythtv-pacman/tasks/main.yml
+++ b/roles/mythtv-pacman/tasks/main.yml
@@ -61,6 +61,7 @@
       - python-requests
       - python-simplejson
       - python-future
+      - python-setuptools
 
 - name: add mythtv essential perl modules
   set_fact:


### PR DESCRIPTION
Depending on how one installs arch, python-setuptools
may not get added to the OS.  Add it explicitly.

Fixes: #15 