### PR TITLE
Remove qt5 webkit libraries from default package list

### DIFF
--- a/roles/qt5/tasks/qt5-suse.yml
+++ b/roles/qt5/tasks/qt5-suse.yml
@@ -2,8 +2,6 @@
   set_fact:
     zypper_pkg_lst:
       - libqt5-qtbase-devel
-      - libQt5WebKit5-devel
-      - libQt5WebKitWidgets-devel
       - libqt5-qtscript-devel
   tags:
     - qt5


### PR DESCRIPTION
Tumbleweed no longer provides the qt5webkit librarians.  This is a modification of e97b6fc4e and deb2eb88 