### PR TITLE
OSX: use pip3 to install py-requests

### DIFF
--- a/roles/mythtv-macports/tasks/main.yml
+++ b/roles/mythtv-macports/tasks/main.yml
@@ -95,6 +95,7 @@
       - py{{ python_package_suffix }}-wheel
       - py{{ python_package_suffix }}-pymysql
       - py{{ python_package_suffix }}-pip
+      - py{{ python_package_suffix }}-virtualenv
 
 - name: add perl essentials
   set_fact:
@@ -145,10 +146,17 @@
     - { group: mysql,  version: '{{ database_version }}' }
     - { group: python,  version: 'python{{ python_package_suffix }}' }
     - { group: python3, version: 'python{{ python_package_suffix }}' }
+    - { group: pip3, version: 'pip{{ python_package_suffix }}' }
 
 - name: install py-mysqlclient (for mariadb/mysqldb)
   macports:
     name: py{{ python_package_suffix }}-mysqlclient
     variant: +{{ mysql_variant }}
+
+- name: install ttvdb4.py compatible version of py-requests
+  pip:
+      name: requests-cache==0.5.2
+      executable: pip3
+  tags: pip
 
 # vim: set expandtab tabstop=2 shiftwidth=2 smartindent noautoindent colorcolumn=2:


### PR DESCRIPTION
  Currently macports has a newer/incompatible version in its ports repo
  This will need to be backed out if/when ttvdb4.py and tvmaze.py get updated
  to a newer py-requests-cache