### PR TITLE
OSX: add ports for VA1 support in FFmpeg

### DIFF
--- a/roles/mythtv-macports/tasks/main.yml
+++ b/roles/mythtv-macports/tasks/main.yml
@@ -65,6 +65,8 @@
       - libass
       - x264
       - x265
+      - aom
+      - dav1d
       - libvpx
       - minizip
       - apache-ant


### PR DESCRIPTION
Add ports aom and dav1d now that they are available in the ports tree to support AV1 in FFmpeg