### PR TITLE
Update github workflow tests with current distro releases

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -48,6 +48,9 @@ jobs:
           - desc: 'Ubuntu 22.10 (Kinetic Kudu)'
             image: 'ubuntu:22.10'
             ansibleopts: '--limit localhost'
+          - desc: 'Ubuntu 23.04 (Lunar Lobster)'
+            image: 'ubuntu:23.04'
+            ansibleopts: '--limit localhost'
 
           # Debian group
           - desc: 'Debian 11 (Bullseye)'
@@ -58,14 +61,14 @@ jobs:
             ansibleopts: '--limit localhost'
 
           # Fedora group
-          - desc: 'Fedora 35'
-            image: 'fedora:35'
-            ansibleopts: '--limit localhost'
           - desc: 'Fedora 36'
             image: 'fedora:36'
             ansibleopts: '--limit localhost'
           - desc: 'Fedora 37'
             image: 'fedora:37'
+            ansibleopts: '--limit localhost'
+          - desc: 'Fedora 38'
+            image: 'fedora:38'
             ansibleopts: '--limit localhost'
           - desc: 'Fedora Rawhide'
             image: 'fedora:rawhide'

--- a/.github/workflows/build-mythtv-core.yml
+++ b/.github/workflows/build-mythtv-core.yml
@@ -3,7 +3,7 @@ name: Build MythTV core variants
 
 #
 # This workflow is intended to provide good coverage
-# quickly to insure that the build "basicall" works.
+# quickly to insure that the build "basically" works.
 #
 # The containers are selected to be from the set of
 # linux distributions and versions that are currently
@@ -53,9 +53,12 @@ jobs:
             image: 'ubuntu:22.04'
             ansibleopts: '--limit localhost'
             configureopts: ''
-
           - desc: 'Ubuntu 22.10 (Kinetic Kudu)'
             image: 'ubuntu:22.10'
+            ansibleopts: '--limit localhost'
+            configureopts: ''
+          - desc: 'Ubuntu 23.04 (Lunar Lobster)'
+            image: 'ubuntu:23.04'
             ansibleopts: '--limit localhost'
             configureopts: ''
 
@@ -70,16 +73,16 @@ jobs:
             configureopts: ''
 
           # Fedora group
-          - desc: 'Fedora 35'
-            image: 'fedora:35'
-            ansibleopts: '--limit localhost'
-            configureopts: ''
           - desc: 'Fedora 36'
             image: 'fedora:36'
             ansibleopts: '--limit localhost'
             configureopts: ''
           - desc: 'Fedora 37'
             image: 'fedora:37'
+            ansibleopts: '--limit localhost'
+            configureopts: ''
+          - desc: 'Fedora 38'
+            image: 'fedora:38'
             ansibleopts: '--limit localhost'
             configureopts: ''
 


### PR DESCRIPTION
Add in Ubuntu 23.04 (Lunar Lobster), and Fedora 38, and delete Fedora 35 to reflect current supported targets.