### PR TITLE
Add python3-pip as build dependency

### DIFF
--- a/roles/mythtv-deb/tasks/debian.yml
+++ b/roles/mythtv-deb/tasks/debian.yml
@@ -150,6 +150,14 @@
   when:
     - ansible_distribution_release == "bookworm" or ansible_distribution_major_version|int >= 11
 
+- name: add python3-pip module (bookworm and later)
+  set_fact:
+    deb_pkg_lst:
+      - '{{ deb_pkg_lst }}'
+      - python3-pip
+  when:
+    - ansible_distribution_release == "bookworm" or ansible_distribution_major_version|int >= 12
+
 - name: make adjustments for bookworm or >= 12 package here
   block:
     - set_fact:

--- a/roles/mythtv-deb/tasks/ubuntu.yml
+++ b/roles/mythtv-deb/tasks/ubuntu.yml
@@ -83,6 +83,14 @@
   when:
     - ansible_lsb.major_release|int >= 20
 
+- name: add python3-pip module (23.04 and later)
+  set_fact:
+    deb_pkg_lst:
+      - '{{ deb_pkg_lst }}'
+      - python3-pip
+  when:
+    - ansible_lsb.major_release|int >= 23
+
 - name: add mythtv essential plugin libraries (16.04 and later)
   set_fact:
     deb_pkg_lst:

--- a/roles/mythtv-dnf/tasks/main.yml
+++ b/roles/mythtv-dnf/tasks/main.yml
@@ -209,10 +209,11 @@
   when: (ansible_distribution == "CentOS" and ansible_distribution_major_version|int > 8) or
         (ansible_distribution == "Rocky" and ansible_distribution_major_version|int > 8)
 
-- name: add python3-pip module - Fedora 39+
+- name: add python3-pip and wheel modules - Fedora 39+
   set_fact:
     dnf_pkg_lst:
       - '{{ dnf_pkg_lst }}'
+      - python3-wheel
       - python3-pip
   when:
     - ansible_distribution == "Fedora" and ansible_distribution_version|int >= 39

--- a/roles/mythtv-dnf/tasks/main.yml
+++ b/roles/mythtv-dnf/tasks/main.yml
@@ -209,6 +209,14 @@
   when: (ansible_distribution == "CentOS" and ansible_distribution_major_version|int > 8) or
         (ansible_distribution == "Rocky" and ansible_distribution_major_version|int > 8)
 
+- name: add python3-pip module - Fedora 39+
+  set_fact:
+    dnf_pkg_lst:
+      - '{{ dnf_pkg_lst }}'
+      - python3-pip
+  when:
+    - ansible_distribution == "Fedora" and ansible_distribution_version|int >= 39
+
 - name: add mythtv essential perl modules
   set_fact:
     dnf_pkg_lst:


### PR DESCRIPTION
Commit https://github.com/MythTV/mythtv/commit/8ece26b added python3-pip as build dependency (in configure) for modern Linux variants.

Updated specs for Ubuntu >= 23.04, Debian 12 and Fedora 39+.

 - MythTV master for Ubuntu 23.04 is already build with python3-pip on Launchpad.
 - Debian 12 has a recent version of python3-pip.
 - Fedora 39, once released has python3.12 which requires python3-pip for building.

Note: For Debian and its derivatives, the package python3-pip depends on python3-wheel.

Completely untested.