### PR TITLE
ci: update github workflow distro versions

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -45,11 +45,11 @@ jobs:
           - desc: 'Ubuntu 22.04 LTS (Jammy Jellyfish)'
             image: 'ubuntu:22.04'
             ansibleopts: '--limit localhost'
-          - desc: 'Ubuntu 22.10 (Kinetic Kudu)'
-            image: 'ubuntu:22.10'
-            ansibleopts: '--limit localhost'
           - desc: 'Ubuntu 23.04 (Lunar Lobster)'
             image: 'ubuntu:23.04'
+            ansibleopts: '--limit localhost'
+          - desc: 'Ubuntu 23.10 (Mantic Minotaur)'
+            image: 'ubuntu:23.10'
             ansibleopts: '--limit localhost'
 
           # Debian group
@@ -61,9 +61,6 @@ jobs:
             ansibleopts: '--limit localhost'
 
           # Fedora group
-          - desc: 'Fedora 37'
-            image: 'quay.io/fedora/fedora:37'
-            ansibleopts: '--limit localhost'
           - desc: 'Fedora 38'
             image: 'quay.io/fedora/fedora:38'
             ansibleopts: '--limit localhost'

--- a/.github/workflows/build-mythtv-core.yml
+++ b/.github/workflows/build-mythtv-core.yml
@@ -53,12 +53,12 @@ jobs:
             image: 'ubuntu:22.04'
             ansibleopts: '--limit localhost'
             configureopts: ''
-          - desc: 'Ubuntu 22.10 (Kinetic Kudu)'
-            image: 'ubuntu:22.10'
-            ansibleopts: '--limit localhost'
-            configureopts: ''
           - desc: 'Ubuntu 23.04 (Lunar Lobster)'
             image: 'ubuntu:23.04'
+            ansibleopts: '--limit localhost'
+            configureopts: ''
+          - desc: 'Ubuntu 23.10 (Mantic Minotaur)'
+            image: 'ubuntu:23.10'
             ansibleopts: '--limit localhost'
             configureopts: ''
 
@@ -73,10 +73,6 @@ jobs:
             configureopts: ''
 
           # Fedora group
-          - desc: 'Fedora 37'
-            image: 'quay.io/fedora/fedora:37'
-            ansibleopts: '--limit localhost'
-            configureopts: ''
           - desc: 'Fedora 38'
             image: 'quay.io/fedora/fedora:38'
             ansibleopts: '--limit localhost'


### PR DESCRIPTION
Fedora 37 is near EOL
Ubuntu 22.10 is no longer supported
Ubuntu 23.10 is now the current interim release
