### PR TITLE
Fix typo in mythtv-dnf (list -> lst) for libcrystalhd

### DIFF
--- a/roles/mythtv-dnf/tasks/main.yml
+++ b/roles/mythtv-dnf/tasks/main.yml
@@ -117,7 +117,7 @@
 
 - name: add optional build libraries
   set_fact:
-    dnf_pkg_list:
+    dnf_pkg_lst:
       - '{{ dnf_pkg_lst }}'
       - libcrystalhd-devel
   when: (ansible_distribution == "Fedora") or


### PR DESCRIPTION
Commit 273c44c5c0 introduced the typo during the
reorganization to support EL9.