### PR TITLE
macOS: cleanup, mysqlclient fix, and update hombrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,20 +69,32 @@ For Qt6 support, add ``` -e "qt6=true" ``` to the end of the command line. E.G.
 ``` ./mythtv.yml --limit=localhost -e "qt6=true" ```
 
 #### MacOSX Homebrew Users
-```brew install ansible```<br>
-```./mythtv.yml --limit=localhost```
+``` brew install ansible ```<br>
+``` ./mythtv.yml --limit=localhost ```
+
+To disable the sudo / become prompt run add
+``` ANSIBLE_BECOME=false ANSIBLE_BECOME_ASK_PASS=False ```
+to the beginning of the command line (homebrew is already set to run
+without escalting priveldges in the homebrew playbook). E.G.
+
+``` ANSIBLE_BECOME=false ANSIBLE_BECOME_ASK_PASS=False ./mythtv.yml --limit=localhost ```
+
 
 #### MacOSX MacPorts Users
-```sudo port install py311-ansible```<br>
-```./mythtv.yml --limit=localhost```
+``` sudo port install py311-ansible ```<br>
+``` ./mythtv.yml --limit=localhost ```
 
 - Optionally specify a database version:
 
     ``` ./mythtv.yml --extra-vars="database_version=mariadb-10.5" --limit=localhost ```
 
--    Optionally do not install qtwebkit:
+- Optionally do not install qtwebkit:
 
     ``` ./mythtv.yml --extra-vars="install_qtwebkit=false" --limit=localhost ```
+
+- Optionally specify a different version of python3
+
+   ``` ./mythtv.yml --extra-vars="ansible_python_interpreter=/opt/local/bin/python3.11"  --limit=localhost ```
 
 ## Other Platforms
 We welcome contributions to support additional platforms. Please contact the

--- a/hosts.yml
+++ b/hosts.yml
@@ -25,7 +25,7 @@ mythtv_hosts:
         homebrew:
           ansible_python_interpreter: ${HOMEBREW_PREFIX}/bin/python3
         macports:
-          ansible_python_interpreter: /opt/local/bin/python3.11
+          ansible_python_interpreter: /opt/local/bin/python3
     builder:
       mythtv_builders: true
       tags: never

--- a/roles/mythtv-homebrew/tasks/main.yml
+++ b/roles/mythtv-homebrew/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: specify a mariadb/mysql version to install
   set_fact:
-    database_version=mysql
+    database_version=mysql@8.0
   when:
     database_version is undefined
 
@@ -38,22 +38,23 @@
     homebrew_pkg_list:
       - '{{ homebrew_pkg_list }}'
       - libxml2
+      - libxslt
       - taglib
       - exiv2
       - libbluray
       - lzo
       - libsamplerate
       - libzip
+      - zlib
+      - libiconv
       - glslang
-      - openssl@1.1
-      - openssl@3
+      - openssl
       - '{{ database_version }}'
 
 - name: add optional libraries
   set_fact:
     homebrew_pkg_list:
       - '{{ homebrew_pkg_list }}'
-      - openssl
       - libvpx
       - x264
       - x265
@@ -62,7 +63,6 @@
       - flac
       - faac
       - freetype
-      - libxml2
       - fftw
       - libass
       - aom
@@ -80,7 +80,6 @@
       - molten-vk
       - audiofile
       - libdiscid
-      - http-parser
 
 - name: develop a Python package version suffix
   set_fact:
@@ -110,7 +109,7 @@
       - perl
       - cpanminus
 
-- name: utility packages from ports
+- name: utility packages from homebrew
   set_fact:
     homebrew_pkg_list:
       - '{{ homebrew_pkg_list }}'
@@ -123,7 +122,7 @@
       - texinfo
       - texi2html
 
-- name: print final list of ports
+- name: print final list of packages
   debug:
     msg:
       '{{ lookup("flattened", homebrew_pkg_list) }}'
@@ -146,6 +145,24 @@
   become: false
   command: brew install --cask font-liberation
 
+- name: Get mysqlclient libs
+  shell:
+    export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:"{{ homebrew_prefix }}/opt/{{ database_version }}/lib/pkgconfig/" &&
+    {{ homebrew_prefix }}/bin/pkg-config --libs mysqlclient
+  register: LIBS_OUT
+
+- name: set MYSQLCLIENT_LDFLAGS fact
+  set_fact:  MYSQLCLIENT_LDFLAGS={{ LIBS_OUT.stdout }}
+
+- name: Get mysqlclient cflags
+  shell:
+    export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:"{{ homebrew_prefix }}/opt/{{ database_version }}/lib/pkgconfig/" &&
+    {{ homebrew_prefix }}/bin/pkg-config --cflags mysqlclient
+  register: CFLAG_OUT
+
+- name: set MYSQLCLIENT_CFLAGS fact
+  set_fact:  MYSQLCLIENT_CFLAGS={{ CFLAG_OUT.stdout }}
+
 - name: create Python virtual environment folder for standard user
   become: false
   file:
@@ -167,7 +184,6 @@
       - et
       - features
       - future
-      - HTMLParser
       - httplib2
       - importlib_metadata
       - lxml
@@ -187,6 +203,9 @@
       - urllib3
       - virtualenv
       - wheel
+  environment:
+    MYSQLCLIENT_LDFLAGS: "{{ MYSQLCLIENT_LDFLAGS }}"
+    MYSQLCLIENT_CFLAGS: "{{ MYSQLCLIENT_CFLAGS }}"
   tags: pip
 
 - name: cpanm - install Net-SSLeay perl module with special handling for openssl
@@ -217,10 +236,10 @@
 
 - name: cpanm - install DBD-mysql vwith special handling for mysql8
   become: false
-  command: cpanm
+  shell: cpanm
     --force
     --mirror 'http://cpan.cpantesters.org/'
-    --configure-args="--libs='-L{{ homebrew_prefix }}/lib -lssl -lcrypto -lzstd'"
+    --configure-args="--libs='-L{{ homebrew_prefix }}/lib -lssl -lcrypto -lzstd'
+      --mysql_config='{{ homebrew_prefix }}/opt/{{ database_version }}/bin/mysql_config'"
     DBD::mysql
-
 # vim: set expandtab tabstop=2 shiftwidth=2 smartindent noautoindent colorcolumn=2:

--- a/roles/mythtv-macports/tasks/main.yml
+++ b/roles/mythtv-macports/tasks/main.yml
@@ -2,6 +2,13 @@
 
 ---
 
+- name: Get macports install prefix
+  shell:  dirname $(dirname $(which port))
+  register: MP_OUT
+
+- name: set macports_prefix fact
+  set_fact:  macports_prefix={{ MP_OUT.stdout  }}
+
 - name: specify a mariadb/mysql version to install
   set_fact:
     database_version=mysql8
@@ -40,6 +47,7 @@
     macports_pkg_list:
       - '{{ macports_pkg_list }}'
       - libxml2
+      - libxslt
       - taglib
       - exiv2
       - libbluray
@@ -61,7 +69,6 @@
       - flac
       - faac
       - freetype
-      - libxml2
       - fftw-3
       - libass
       - aom
@@ -142,11 +149,29 @@
 - name: select the installed version of mariadb/mysql and python
   command: 'port select --set {{ item.group }} {{ item.version }}'
   with_list:
-    - {group: mysql, version: '{{ database_version }}'}
-    - {group: python, version: 'python{{ python_package_suffix }}'}
-    - {group: python3, version: 'python{{ python_package_suffix }}'}
-    - {group: pip3, version: 'pip{{ python_package_suffix }}'}
-    - {group: virtualenv, version: 'virtualenv{{ python_package_suffix }}'}
+    - { group: mysql, version: '{{ database_version }}' }
+    - { group: python, version: 'python{{ python_package_suffix }}' }
+    - { group: python3, version: 'python{{ python_package_suffix }}' }
+    - { group: pip3, version: 'pip{{ python_package_suffix }}' }
+    - { group: virtualenv, version: 'virtualenv{{ python_package_suffix }}' }
+
+- name: Get mysqlclient libs
+  shell:
+    export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:{{ macports_prefix }}/lib/{{ database_version }}/pkgconfig/ &&
+    {{ macports_prefix }}/bin/pkg-config --libs mysqlclient
+  register: LIBS_OUT
+
+- name: set MYSQLCLIENT_LDFLAGS fact
+  set_fact:  MYSQLCLIENT_LDFLAGS={{ LIBS_OUT.stdout }}
+
+- name: Get mysqlclient cflags
+  shell:
+    export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:{{ macports_prefix }}/lib/{{ database_version }}/pkgconfig/ &&
+    {{ macports_prefix }}/bin/pkg-config --cflags mysqlclient
+  register: CFLAG_OUT
+
+- name: set MYSQLCLIENT_CFLAGS fact
+  set_fact:  MYSQLCLIENT_CFLAGS={{ CFLAG_OUT.stdout }}
 
 - name: create Python virtual environment folder for standard user
   become: false
@@ -190,6 +215,9 @@
       - 'urllib3'
       - 'virtualenv'
       - 'wheel'
+  environment:
+    MYSQLCLIENT_LDFLAGS: "{{ MYSQLCLIENT_LDFLAGS }}"
+    MYSQLCLIENT_CFLAGS: "{{ MYSQLCLIENT_CFLAGS }}"
   tags: pip
 
 # vim: set expandtab tabstop=2 shiftwidth=2 smartindent noautoindent colorcolumn=2:


### PR DESCRIPTION
  Update README.md

  macport and homebrew:
  - remove obsolete or repeated packages

  homebrew:
  - add zlib and libiconv dependencies

  mysqlclient / pip
  On macports, python mysqlclient needs extra help to locate mysql8+
  - Add a variable to point to macports prefix directory
  - Use pkg-config to locate both the MYSQLCLIENT_LDFLAGS and MYSQLCLIENT_CFLAGS variables
  - Feed MYSQLCLIENT_LDFLAGS and MYSQLCLIENT_CFLAGS variables to pip to aide mysqlclient install