### PR TITLE
Enable manual ansible workflow dispatch

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -23,6 +23,8 @@ on:                # yamllint disable-line rule:truthy
 
   pull_request:
 
+  workflow_dispatch:
+
 permissions:
   contents: read
 


### PR DESCRIPTION
This adds a "Run Workflow" button on the github actions tab for the "Run ansible-playbook" workflow.