### PR TITLE
OSX: remove vulkan until its fixed upstream

### DIFF
--- a/roles/mythtv-macports/tasks/main.yml
+++ b/roles/mythtv-macports/tasks/main.yml
@@ -80,10 +80,10 @@
       - liberation-fonts
       - dejavu-fonts
       - soundtouch
-      - vulkan-headers
-      - vulkan-tools
-      - vulkan-loader
-      - MoltenVK
+      #- vulkan-headers
+      #- vulkan-tools
+      #- vulkan-loader
+      #- MoltenVK
 
 - name: develop a Python package version suffix
   set_fact:


### PR DESCRIPTION
Vulkan is currently broken in upstream macports.  Additionally, it is not yet in qt5/6 (a PR has been issued and in the queue).  This PR comments out the packages until both issues are resolved.