### PR TITLE
Remove centos-stream-8 from ansible builds

### DIFF
--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -74,9 +74,6 @@ jobs:
             ansibleopts: '--limit localhost'
 
           # CentOS group
-          - desc: 'CentOS 8 Stream'
-            image: 'quay.io/centos/centos:stream8'
-            ansibleopts: '--limit localhost'
           - desc: 'CentOS 9 Stream'
             image: 'quay.io/centos/centos:stream9'
             ansibleopts: '--limit localhost'


### PR DESCRIPTION
For various reasons, the centos-stream-8 container points to a set of invalid mirrorlists.  Upstream has not chosen to clean this up.  While it would  be possible to adjust the workflow steps to adjust for this, just eliminate the build, as other than a few uninstalled packages (such as the kernel and grub), rocky-8 (which we also build) covers all the same packages.