### PR TITLE
No longer attempt to install python3-future for Fedora 41 (and beyond)

### DIFF
--- a/roles/mythtv-dnf/tasks/main.yml
+++ b/roles/mythtv-dnf/tasks/main.yml
@@ -189,11 +189,19 @@
       - '{{ dnf_pkg_lst }}'
       - python3-lxml
       - python3-libselinux
-      - python3-future
       - python3-requests-cache
       - python3-simplejson
       - python3-setuptools
   when: (ansible_distribution == "Fedora" and ansible_distribution_version|int >= 30) or
+        (ansible_distribution == "CentOS") or
+        (ansible_distribution == "Rocky")
+
+- name: add additional essential python3 modules - Fedora 30 to 40, Centos
+  set_fact:
+    dnf_pkg_lst:
+      - '{{ dnf_pkg_lst }}'
+      - python3-future
+  when: (ansible_distribution == "Fedora" and ansible_distribution_version|int >= 30 and ansible_distribution_version|int <= 40) or
         (ansible_distribution == "CentOS") or
         (ansible_distribution == "Rocky")
 


### PR DESCRIPTION
Fedora with F41 (and beyond) will not package python3-future.  Do not try to install it.