### PR TITLE
macOS: pin setuptools to 70.3.0

### DIFF
--- a/roles/mythtv-macports/tasks/main.yml
+++ b/roles/mythtv-macports/tasks/main.yml
@@ -213,6 +213,7 @@
       - traceback2
       - urllib3
       - wheel
+      - setuptools==70.3.0
   environment:
     MYSQLCLIENT_LDFLAGS: "{{ MYSQLCLIENT_LDFLAGS }}"
     MYSQLCLIENT_CFLAGS: "{{ MYSQLCLIENT_CFLAGS }}"


### PR DESCRIPTION
  py2app used in the macOS compile script requires setuptools to
  bundles python modules into the app bundle.  Currently, py2app is
  broken with setuptools versions > 70.3.0.  This should be backed out
  one py2app is fixed