### PR TITLE
macOS: Update macports, hombrew playbooks to use new pip role

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Archlinux | pacman -S ansible
 Centos | yum install ansible (enable the [EPEL](https://fedoraproject.org/wiki/EPEL) repository first)
 Debian (and derivatives) | apt install ansible
 Fedora | dnf install ansible
-MacOSX (macports) | port install py311-ansible
+MacOSX (macports) | port install py-ansible
 MacOSX (homebrew) | brew install ansible
 FreeBSD | pkg install py27-ansible
 OpenSuse | zypper install ansible
@@ -81,7 +81,7 @@ without escalating privileges in the homebrew playbook). E.g.
 
 
 #### MacOSX MacPorts Users
-``` sudo port install py311-ansible ```<br>
+``` sudo port install py-ansible ```<br>
 ``` ./mythtv.yml --limit=localhost ```
 
 - Optionally specify a database version:

--- a/mythtv.yml
+++ b/mythtv.yml
@@ -70,6 +70,10 @@
         - not mythtv_tools
 
     - include_role:
+        name: pip
+      when: not mythtv_tools
+
+    - include_role:
         name: qt5
       when:
         - not mythtv_tools

--- a/roles/mythtv-homebrew/tasks/main.yml
+++ b/roles/mythtv-homebrew/tasks/main.yml
@@ -2,26 +2,22 @@
 
 ---
 - name: Get homebrew install prefix
-  command:  brew --prefix
+  command: brew --prefix
   register: HB_OUT
 
-- name: set homebrew_prefix fact
-  set_fact:  homebrew_prefix={{ HB_OUT.stdout  }}
+- name: set pkgmgr_prefix fact
+  set_fact: pkgmgr_prefix={{ HB_OUT.stdout  }}
 
 - name: specify a mariadb/mysql version to install
-  set_fact:
-    database_version=mysql
-  when:
-    database_version is undefined
+  set_fact: database_version=mariadb
+  when: database_version is undefined
 
 - name: check if this is a mariadb based install
-  set_fact:
-    database_name=mariadb
+  set_fact: database_name=mariadb
   when: database_version is search("mariadb")
 
 - name: check if this is a mysql based install
-  set_fact:
-    database_name=mysql
+  set_fact: database_name=mysql
   when: database_version is search("mysql")
 
 - name: create a list of compilers and build essentials
@@ -38,6 +34,8 @@
       - gperf
       - meson
 
+# note that on homebrew, mysql-client
+# is required to get the python mysqlclient working
 - name: add essential libraries
   set_fact:
     homebrew_pkg_list:
@@ -55,6 +53,7 @@
       - glslang
       - openssl
       - '{{ database_version }}'
+      - mysql-client
 
 - name: add optional libraries
   set_fact:
@@ -76,6 +75,7 @@
       - ant
       - libhdhomerun
       - libX11
+      - php
       - sound-touch
       - libcec
       - zstd
@@ -87,14 +87,18 @@
 
 - name: develop a Python package version suffix
   set_fact:
+    python_package_suffix:
+      '{{ ansible_python.version.major }}{{ ansible_python.version.minor }}'
     python_exe_suffix:
       '{{ ansible_python.version.major }}.{{ ansible_python.version.minor }}'
+
 
 - name: add python essentials
   set_fact:
     homebrew_pkg_list:
       - '{{ homebrew_pkg_list }}'
       - 'python@{{ python_exe_suffix }}'
+      - python-setuptools
       - virtualenv
       - pyenv-virtualenv
 
@@ -119,6 +123,8 @@
       - curl
       - texinfo
       - texi2html
+      - font-dejavu
+      - font-liberation
 
 - name: print final list of packages
   debug:
@@ -131,22 +137,11 @@
     name:
       '{{ lookup("flattened", homebrew_pkg_list) }}'
 
-- name: add fonts cask to homebrew
-  become: false
-  command: brew tap homebrew/cask-fonts
-
-- name: install dejavu fonts from brew cask
-  become: false
-  command: brew install --cask font-dejavu
-
-- name: install liberation fonts from brew cask
-  become: false
-  command: brew install --cask font-liberation
 
 - name: Get mysqlclient libs
   shell:
-    export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:"{{ homebrew_prefix }}/opt/{{ database_version }}/lib/pkgconfig/" &&
-    {{ homebrew_prefix }}/bin/pkg-config --libs mysqlclient
+    export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:"{{ pkgmgr_prefix }}/opt/mysql-client/lib/pkgconfig/" &&
+    {{ pkgmgr_prefix }}/bin/pkg-config --libs mysqlclient
   register: LIBS_OUT
 
 - name: set MYSQLCLIENT_LDFLAGS fact
@@ -154,90 +149,44 @@
 
 - name: Get mysqlclient cflags
   shell:
-    export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:"{{ homebrew_prefix }}/opt/{{ database_version }}/lib/pkgconfig/" &&
-    {{ homebrew_prefix }}/bin/pkg-config --cflags mysqlclient
+    export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:"{{ pkgmgr_prefix }}/opt/mysql-client/lib/pkgconfig/" &&
+    {{ pkgmgr_prefix }}/bin/pkg-config --cflags mysqlclient
   register: CFLAG_OUT
 
 - name: set MYSQLCLIENT_CFLAGS fact
   set_fact:  MYSQLCLIENT_CFLAGS={{ CFLAG_OUT.stdout }}
 
-- name: create Python virtual environment folder for standard user
-  become: false
-  file:
-    name: ~/.mythtv/python-virtualenv
-    state: directory
+- name: create a list of compilers and build essentials
+  set_fact:
+    cpanm_pkg_list:
+      - Date::Manip
+      - DateTime::Format::ISO8601
+      - Image::Size
+      - IO::Socket::INET6
+      - JSON
+      - LWP
+      - HTTP::Request::AsCGI
+      - Net::UPnP
+      - Net::SSLeay
+      - SOAP::Lite
+      - XML::XPath
+      - XML::Simple
+      - FindBin
+      - IPC::Cmd
 
-- name: initiate virtualenv for standard user
-  become: false
-  pip:
-    virtualenv: ~/.mythtv/python-virtualenv
-    name:
-      - argparse
-      - audiofile
-      - bs4
-      - common
-      - configparser
-      - cryptography
-      - datetime
-      - discid
-      - et
-      - features
-      - future
-      - HTMLParser
-      - httplib2
-      - importlib_metadata
-      - lxml
-      - musicbrainzngs
-      - mysqlclient
-      - oauthlib
-      - py2app
-      - pycurl
-      - python_dateutil
-      - requests
-      - requests_cache==0.5.2
-      - simplejson
-      - traceback2
-      - urllib3
-      - wheel
-  environment:
-    MYSQLCLIENT_LDFLAGS: "{{ MYSQLCLIENT_LDFLAGS }}"
-    MYSQLCLIENT_CFLAGS: "{{ MYSQLCLIENT_CFLAGS }}"
-  tags: pip
-
-- name: cpanm - install Net-SSLeay perl module with special handling for openssl
-  become: false
-  command: cpanm
-    --mirror 'http://cpan.cpantesters.org/'
-    --force
-    --configure-args="--libs='-L{{ homebrew_prefix }}/lib' --inc='-I{{ homebrew_prefix }}/opt/openssl/'"
-    Net::SSLeay
+- name: print final list of cpanm packages
+  debug:
+    msg:
+      '{{ lookup("flattened", cpanm_pkg_list) }}'
 
 - name: cpanm - install perl modules
   become: false
   command: cpanm
     --mirror 'http://cpan.cpantesters.org/'
     --force
-    Date::Manip
-    DateTime::Format::ISO8601
-    Image::Size
-    IO::Socket::INET6
-    JSON
-    LWP
-    HTTP::Request::AsCGI
-    Net::UPnP
-    SOAP::Lite
-    XML::XPath
-    XML::Simple
-    FindBin
-    IPC::Cmd
+    {{  cpanm_pkg_list | join(' ')  }}
+  ignore_errors: yes
+  environment:
+    OPENSSL_PREFIX: "{{ pkgmgr_prefix }}/opt/openssl/"
 
-
-- name: cpanm - install DBD-mysql vwith special handling for mysql8
-  become: false
-  shell: cpanm
-    --force
-    --mirror 'http://cpan.cpantesters.org/'
-    --configure-args="--libs='-L{{ homebrew_prefix }}/lib -lssl -lcrypto -lzstd'
-      --mysql_config='{{ homebrew_prefix }}/opt/{{ database_version }}/bin/mysql_config'"
-    DBD::mysql
 # vim: set expandtab tabstop=2 shiftwidth=2 smartindent noautoindent colorcolumn=2:

--- a/roles/mythtv-macports/tasks/main.yml
+++ b/roles/mythtv-macports/tasks/main.yml
@@ -3,11 +3,11 @@
 ---
 
 - name: Get macports install prefix
-  shell:  dirname $(dirname $(which port))
+  shell: dirname $(dirname $(which port))
   register: MP_OUT
 
-- name: set macports_prefix fact
-  set_fact:  macports_prefix={{ MP_OUT.stdout  }}
+- name: set pkgmgr_prefix fact
+  set_fact: pkgmgr_prefix={{ MP_OUT.stdout  }}
 
 - name: specify a mariadb/mysql version to install
   set_fact:
@@ -72,6 +72,7 @@
       - freetype
       - fftw-3
       - libass
+      - php84
       - aom
       - dav1d
       - minizip
@@ -81,10 +82,6 @@
       - liberation-fonts
       - dejavu-fonts
       - soundtouch
-      #- vulkan-headers
-      #- vulkan-tools
-      #- vulkan-loader
-      #- MoltenVK
 
 - name: develop a Python package version suffix
   set_fact:
@@ -154,69 +151,25 @@
     - { group: python, version: 'python{{ python_package_suffix }}' }
     - { group: python3, version: 'python{{ python_package_suffix }}' }
     - { group: pip3, version: 'pip{{ python_package_suffix }}' }
+    - { group: php, version: 'php84' }
     - { group: virtualenv, version: 'virtualenv{{ python_package_suffix }}' }
 
 - name: Get mysqlclient libs
   shell:
-    export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:{{ macports_prefix }}/lib/{{ database_version }}/pkgconfig/ &&
-    {{ macports_prefix }}/bin/pkg-config --libs mysqlclient
+    export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:{{ pkgmgr_prefix }}/lib/{{ database_version }}/pkgconfig/ &&
+    {{ pkgmgr_prefix }}/bin/pkg-config --libs mysqlclient
   register: LIBS_OUT
 
 - name: set MYSQLCLIENT_LDFLAGS fact
-  set_fact:  MYSQLCLIENT_LDFLAGS={{ LIBS_OUT.stdout }}
+  set_fact: MYSQLCLIENT_LDFLAGS={{ LIBS_OUT.stdout }}
 
 - name: Get mysqlclient cflags
   shell:
-    export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:{{ macports_prefix }}/lib/{{ database_version }}/pkgconfig/ &&
-    {{ macports_prefix }}/bin/pkg-config --cflags mysqlclient
+    export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:{{ pkgmgr_prefix }}/lib/{{ database_version }}/pkgconfig/ &&
+    {{ pkgmgr_prefix }}/bin/pkg-config --cflags mysqlclient
   register: CFLAG_OUT
 
 - name: set MYSQLCLIENT_CFLAGS fact
-  set_fact:  MYSQLCLIENT_CFLAGS={{ CFLAG_OUT.stdout }}
-
-- name: create Python virtual environment folder for standard user
-  become: false
-  file:
-    name: ~/.mythtv/python-virtualenv
-    state: directory
-
-- name: initiate virtualenv for standard user
-  become: false
-  pip:
-    virtualenv: ~/.mythtv/python-virtualenv
-    virtualenv_python: python{{ python_exe_suffix }}
-    name:
-      - argparse
-      - audiofile
-      - bs4
-      - common
-      - configparser
-      - cryptography
-      - datetime
-      - discid
-      - et
-      - features
-      - future
-      - HTMLParser
-      - httplib2
-      - importlib_metadata
-      - lxml
-      - musicbrainzngs
-      - mysqlclient
-      - oauthlib
-      - py2app
-      - pycurl
-      - python_dateutil
-      - requests
-      - requests_cache==0.5.2
-      - simplejson
-      - traceback2
-      - urllib3
-      - wheel
-      - setuptools==70.3.0
-  environment:
-    MYSQLCLIENT_LDFLAGS: "{{ MYSQLCLIENT_LDFLAGS }}"
-    MYSQLCLIENT_CFLAGS: "{{ MYSQLCLIENT_CFLAGS }}"
-  tags: pip
+  set_fact: MYSQLCLIENT_CFLAGS={{ CFLAG_OUT.stdout }}
 
 # vim: set expandtab tabstop=2 shiftwidth=2 smartindent noautoindent colorcolumn=2:

--- a/roles/pip/tasks/main.yml
+++ b/roles/pip/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+
+- name: create a list of required python packages
+  set_fact:
+    python_pkg_list:
+      - lxml
+      - mysqlclient
+      - oauth
+      - pip>=23.0.1
+      - pycurl
+      - requests
+      - requests-cache
+      - setuptools
+      - urllib3
+      - wheel
+
+- name: add optional python packages
+  set_fact:
+    python_pkg_list:
+      - '{{ python_pkg_list }}'
+      - argparse
+      - audiofile
+      - bs4
+      - common
+      - configparser
+      - cryptography
+      - datetime
+      - discid
+      - et
+      - features
+      - HTMLParser
+      - httplib2
+      - importlib_metadata
+      - markupsafe
+      - musicbrainzngs
+      - oauthlib
+      - python_dateutil
+      - simplejson
+      - traceback2
+
+- name: print final list of python packages
+  debug:
+    msg:
+      '{{ lookup("flattened", python_pkg_list) }}'
+
+- include_tasks:  pip-macOS.yaml
+  when: (ansible_pkg_mgr == "homebrew") or
+    (ansible_pkg_mgr == "macports")
+
+# vim: set expandtab tabstop=2 shiftwidth=2 smartindent noautoindent colorcolumn=2:

--- a/roles/pip/tasks/pip-macOS.yaml
+++ b/roles/pip/tasks/pip-macOS.yaml
@@ -1,0 +1,46 @@
+# roles/pip/tasks/pip-macOS
+
+# Assumes that these variables are set in the macports or
+# homebrew playbooks:
+#
+#   database_version      - specifies the database being used
+#   python_package_suffix - specifiesd the version of python to use
+#   MYSQLCLIENT_LDFLAGS   - flags to find the mysqlclient dylib
+#   MYSQLCLIENT_CFLAGS    - flags to find the mysqlclient includes
+#
+
+---
+
+- name: specify python exectuables
+  set_fact: py_exe=python{{ python_exe_suffix }}
+
+- name: specify a location to install the python virtual environment
+  set_fact: pvenv_location=~/.mythtv/python-venv{{ python_package_suffix }}
+
+- name: expand the use name in the pyvenv location variable
+  set_fact: pvenv_location={{ pvenv_location | expanduser }}
+
+- name: check for previous python virtual environment
+  stat:
+    path: '{{ pvenv_location }}/pyvenv.cfg'
+  register: CHECK_VENV
+
+- name: clearing previous python virtual environment
+  shell: 'rm -Rf {{ pvenv_location }}'
+  register: CHECK_OUT
+  when: CHECK_VENV.stat.exists
+
+- name: generate the python virtual environment for standard user
+  become: false
+  pip:
+    virtualenv: '{{ pvenv_location }}'
+    virtualenv_python: '{{ py_exe }}'
+    virtualenv_site_packages: false
+    name:
+      '{{ lookup("flattened", python_pkg_list) }}'
+  environment:
+    MYSQLCLIENT_LDFLAGS: "{{ MYSQLCLIENT_LDFLAGS }}"
+    MYSQLCLIENT_CFLAGS: "{{ MYSQLCLIENT_CFLAGS }}"
+  tags: pip
+
+# vim: set expandtab tabstop=2 shiftwidth=2 smartindent noautoindent colorcolumn=2:


### PR DESCRIPTION
  Add new pip role to consolidate python package matinenance for macOS
  - Update macport and homebrew to use the new pip role
  - update python modules to the latest python dependencies

  Macports:
  - Update python to 312. Will update to 313 when ansible to updated to allow 313 use

  Homebrew:
  - Correct perl module installation issue with openssl
  - Update fonts packaging nameing convention
  - Add mysqlclient as a required package to help with embedded python issus

  Addtional work done to clean up with yamllint