### PR TITLE
macOS: for homebrew add qt-mariadb/qt-mysql

### DIFF
--- a/roles/mythtv-homebrew/tasks/main.yml
+++ b/roles/mythtv-homebrew/tasks/main.yml
@@ -54,6 +54,7 @@
       - openssl
       - '{{ database_version }}'
       - mysql-client
+      - 'qt-{{ database_version }}'
 
 - name: add optional libraries
   set_fact:


### PR DESCRIPTION
Add qt-mariadb / qt-mysql now that it's an available homebrew formula.