### PR TITLE
macOS: move qt-mysql/qt-mariadb logic in homebrew qt6 playbook

### DIFF
--- a/roles/mythtv-homebrew/tasks/main.yml
+++ b/roles/mythtv-homebrew/tasks/main.yml
@@ -54,7 +54,6 @@
       - openssl
       - '{{ database_version }}'
       - mysql-client
-      - 'qt-{{ database_version }}'
 
 - name: add optional libraries
   set_fact:

--- a/roles/mythtv-homebrew/tasks/main.yml
+++ b/roles/mythtv-homebrew/tasks/main.yml
@@ -155,7 +155,7 @@
 - name: set MYSQLCLIENT_CFLAGS fact
   set_fact:  MYSQLCLIENT_CFLAGS={{ CFLAG_OUT.stdout }}
 
-- name: create a list of compilers and build essentials
+- name: create a list of perl modules
   set_fact:
     cpanm_pkg_list:
       - Date::Manip

--- a/roles/qt6/tasks/qt6-homebrew.yml
+++ b/roles/qt6/tasks/qt6-homebrew.yml
@@ -4,7 +4,7 @@
   set_fact:
     homebrew_pkg_list:
       - qt@6
-      - qt-mysql
+      - 'qt-{{ database_name }}'
   tags:
     - qt6
 


### PR DESCRIPTION
  The correct place to store the qt-mysql/qt-mariadb is in the homebrew
  qt6 playbook.  Update that logic to be in line with the previously
  installed database.