### PR TITLE
macOS: clean up "-" parsing issue and update homebrew python location

### DIFF
--- a/roles/mythtv-homebrew/tasks/main.yml
+++ b/roles/mythtv-homebrew/tasks/main.yml
@@ -27,7 +27,7 @@
       - nasm
       - autoconf
       - automake
-      - pkg-config
+      - 'pkg-config'
       - cmake
       - gpatch
       - ninja
@@ -53,7 +53,7 @@
       - glslang
       - openssl
       - '{{ database_version }}'
-      - mysql-client
+      - 'mysql-client'
 
 - name: add optional libraries
   set_fact:
@@ -76,13 +76,13 @@
       - libhdhomerun
       - libX11
       - php
-      - sound-touch
+      - 'sound-touch'
       - libcec
       - zstd
-      - vulkan-headers
-      - vulkan-tools
-      - vulkan-loader
-      - molten-vk
+      - 'vulkan-headers'
+      - 'vulkan-tools'
+      - 'vulkan-loader'
+      - 'molten-vk'
       - libdiscid
 
 - name: develop a Python package version suffix
@@ -118,12 +118,12 @@
       - libtool
       - lame
       - gnutls
-      - gnu-sed
+      - 'gnu-sed'
       - curl
       - texinfo
       - texi2html
-      - font-dejavu
-      - font-liberation
+      - 'font-dejavu'
+      - 'font-liberation'
 
 - name: print final list of packages
   debug:

--- a/roles/mythtv-macports/tasks/main.yml
+++ b/roles/mythtv-macports/tasks/main.yml
@@ -70,17 +70,17 @@
       - flac
       - faac
       - freetype
-      - fftw-3
+      - 'fftw-3'
       - libass
       - php84
       - aom
       - dav1d
       - minizip
-      - apache-ant
+      - 'apache-ant'
       - hdhomerun
-      - xorg-libX11
-      - liberation-fonts
-      - dejavu-fonts
+      - 'xorg-libX11'
+      - 'liberation-fonts'
+      - 'dejavu-fonts'
       - soundtouch
 
 - name: develop a Python package version suffix
@@ -102,19 +102,19 @@
   set_fact:
     macports_pkg_list:
       - '{{ macports_pkg_list }}'
-      - perl{{ perl_version }}
-      - p{{ perl_version }}-date-manip
-      - p{{ perl_version }}-datetime-format-iso8601
-      - p{{ perl_version }}-dbi
-      - p{{ perl_version }}-image-size
-      - p{{ perl_version }}-io-socket-inet6
-      - p{{ perl_version }}-json
-      - p{{ perl_version }}-libwww-perl
-      - p{{ perl_version }}-http-request-ascgi
-      - p{{ perl_version }}-net-upnp
-      - p{{ perl_version }}-soap-lite
-      - p{{ perl_version }}-xml-xpath
-      - p{{ perl_version }}-xml-simple
+      - 'perl{{ perl_version }}'
+      - 'p{{ perl_version }}-date-manip'
+      - 'p{{ perl_version }}-datetime-format-iso8601'
+      - 'p{{ perl_version }}-dbi'
+      - 'p{{ perl_version }}-image-size'
+      - 'p{{ perl_version }}-io-socket-inet6'
+      - 'p{{ perl_version }}-json'
+      - 'p{{ perl_version }}-libwww-perl'
+      - 'p{{ perl_version }}-http-request-ascgi'
+      - 'p{{ perl_version }}-net-upnp'
+      - 'p{{ perl_version }}-soap-lite'
+      - 'p{{ perl_version }}-xml-xpath'
+      - 'p{{ perl_version }}-xml-simple'
 
 - name: utility packages from ports
   set_fact:

--- a/roles/python/tasks/python-macOS.yml
+++ b/roles/python/tasks/python-macOS.yml
@@ -20,7 +20,7 @@
       - pip>=23.0.1
       - pycurl
       - requests
-      - requests-cache
+      - 'requests-cache'
       - setuptools
       - urllib3
       - wheel
@@ -55,12 +55,12 @@
       '{{ lookup("flattened", python_pkg_list) }}'
 
 - name: specify python exectuables
-  set_fact: py_exe=python{{ python_exe_suffix }}
+  set_fact: py_exe={{ pkgmgr_prefix }}/bin/python{{ python_exe_suffix }}
 
 - name: specify a location to install the python virtual environment
   set_fact: pvenv_location=~/.mythtv/python-venv{{ python_package_suffix }}
 
-- name: expand the use name in the pyvenv location variable
+- name: expand the user name in the pyvenv location variable
   set_fact: pvenv_location={{ pvenv_location | expanduser }}
 
 - name: check for previous python virtual environment


### PR DESCRIPTION
  The ansible output occasionally confuses the "-" in package names
  as a new line indicator.  Clean up the output by encapsulating the
  "-" in quotes.

  Additionally, attempt to correct a x86 homebrew issue where the
  incorrect python is run.