### PR TITLE
macOS: add missing cmake essentials for macports

### DIFF
--- a/roles/mythtv-macports/tasks/main.yml
+++ b/roles/mythtv-macports/tasks/main.yml
@@ -41,6 +41,9 @@
       - autoconf
       - automake
       - pkgconfig
+      - cmake
+      - gpatch
+      - ninja
 
 - name: add essential libraries
   set_fact:


### PR DESCRIPTION
Add ninja, cmake, and gpatch to macports playbook