### PR TITLE
macOS: fix mysql variable names

### DIFF
--- a/roles/python/tasks/python-macOS.yml
+++ b/roles/python/tasks/python-macOS.yml
@@ -80,7 +80,7 @@
     name:
       '{{ lookup("flattened", python_pkg_list) }}'
   environment:
-    MYSQLCLIENT_LDFLAGS: "{{ MYSQLCLIENT_LDFLAGS }}"
-    MYSQLCLIENT_CFLAGS: "{{ MYSQLCLIENT_CFLAGS }}"
+    MYSQLCLIENT_LDFLAGS: "{{ mysqlclient_ldflags }}"
+    MYSQLCLIENT_CFLAGS: "{{ mysqlclient_cflags }}"
 
 # vim: set expandtab tabstop=2 shiftwidth=2 smartindent noautoindent colorcolumn=2:


### PR DESCRIPTION
  Correct a few mysql variables names missed in the lint cleanup