### PR TITLE
Add webengine as dependency for dnf

### DIFF
--- a/roles/qt5/tasks/qt5-dnf.yml
+++ b/roles/qt5/tasks/qt5-dnf.yml
@@ -8,6 +8,7 @@
       - qt5-qtbase-devel
       - qt5-qtwebkit-devel
       - qt5-qtscript-devel
+      - qt5-qtwebengine-devel
       # packages in repo for fedora, and in epel for centos7/rhel7
       # - none yet
   tags:

--- a/roles/qt6/tasks/qt6-dnf.yml
+++ b/roles/qt6/tasks/qt6-dnf.yml
@@ -6,6 +6,7 @@
   set_fact:
     dnf_pkg_lst:
       - qt6-qtbase-devel
+      - qt6-qtwebengine-devel
       # packages in repo for fedora, and in epel for centos7/rhel7
       # - none yet
   tags:


### PR DESCRIPTION
Add webengine for dnf based distributions.

It is likely other distributions also need to add webengine (future work by other interested parties)