### PR TITLE
macOS: Update macports to use qtwebengine

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,6 @@ without escalating privileges in the homebrew playbook). E.g.
 
     ``` ./mythtv.yml --extra-vars="database_version=mariadb-10.5" --limit=localhost ```
 
-- Optionally do not install qtwebkit:
-
-    ``` ./mythtv.yml --extra-vars="install_qtwebkit=false" --limit=localhost ```
-
 - Optionally specify a different version of python3
 
    ``` ./mythtv.yml --extra-vars="ansible_python_interpreter=/opt/local/bin/python3.11"  --limit=localhost ```

--- a/roles/qt5/tasks/qt5-macports.yml
+++ b/roles/qt5/tasks/qt5-macports.yml
@@ -1,11 +1,5 @@
 ---
 
-- name: qt5-macports | Check to see if qtwebkit is requested
-  set_fact:
-    install_qtwebkit: true
-  when:
-    install_qtwebkit is undefined
-
 # parse out database name and major/minor version
 # database_version is set in the macports main.yml
 - name: qt5-macports | Specify mysql/mariadb database version to compile against
@@ -17,16 +11,7 @@
     macports_pkg_list:
       - qt5
       - qt5-qtscript
-  tags:
-    - qt5
-
-# optionally install qtwebkit
-- name: qt5-macports | Check it qtwebkit was requested
-  set_fact:
-    macports_pkg_list:
-      - '{{ macports_pkg_list }}'
-      - qt5-qtwebkit
-  when: install_qtwebkit == "true"
+      - qt5-qtwebengine
   tags:
     - qt5
 

--- a/roles/qt6/tasks/qt6-macports.yml
+++ b/roles/qt6/tasks/qt6-macports.yml
@@ -10,6 +10,7 @@
   set_fact:
     macports_pkg_list:
       - qt6
+      - qt6-qtwebengine
   tags:
     - qt6
 


### PR DESCRIPTION
 Remove all qtwebkit logic from macports qt5/qt6 playbooks replacing
 them with qtwebengine. This isn't needed on homebrew as qtwebkit is
 non-existent there as well as qtwebengine is installed by default with
 qt5/qt6.

 Additionally update the readme to remove the removed qtwebkit variable
 hint.