### PR TITLE
macOS: add libdvdcss to both macports and homebrew playbooks

### DIFF
--- a/roles/mythtv-homebrew/tasks/main.yml
+++ b/roles/mythtv-homebrew/tasks/main.yml
@@ -89,6 +89,7 @@
       - 'molten-vk'
       - libdiscid
       - expat
+      - libdvdcss
 
 - name: Develop a Python package version suffix
   set_fact:

--- a/roles/mythtv-macports/tasks/main.yml
+++ b/roles/mythtv-macports/tasks/main.yml
@@ -86,6 +86,7 @@
       - 'liberation-fonts'
       - 'dejavu-fonts'
       - soundtouch
+      - libdvdcss
 
 - name: Develop a Python package version suffix
   set_fact:


### PR DESCRIPTION
  Add libdvdcss to macports/homebrew playbooks as PR 1156 enables
  package-config location and dynmanically linking automatically
  via cmake.

  Previously this functionality was missing for macOS autobuilds.

  https://github.com/MythTV/mythtv/pull/1156