### PR TITLE
macOS: add missing qt-mysql for homebrew

### DIFF
--- a/roles/mythtv/vars/macosx/homebrew.yml
+++ b/roles/mythtv/vars/macosx/homebrew.yml
@@ -83,9 +83,11 @@ packages:
 
 qt5_packages:
  - qt@5
+ - qt-mysql
 
 qt6_packages:
  - qt@6
+ - qt-mysql
 
 ...
 


### PR DESCRIPTION
I missed a qt-mysql when updating to the new mythtv role.  This PR fixes the omission.