### PR TITLE
macOS: On homebrew, update qt-XXX to variable specified variant

### DIFF
--- a/roles/mythtv/vars/macosx/homebrew.yml
+++ b/roles/mythtv/vars/macosx/homebrew.yml
@@ -83,11 +83,11 @@ packages:
 
 qt5_packages:
  - qt@5
- - qt-mysql
+ - qt-{{ database_version }}
 
 qt6_packages:
  - qt@6
- - qt-mysql
+ - qt-{{ database_version }}
 
 ...
 


### PR DESCRIPTION
  For hoembrew, the user can specify mysql or mariadb as the preffered
  database. This variable needs to be used to specify either the
  qt-mysql or qt-mariadb driver.