### PR TITLE
macOS: fix undefined database_version error

### DIFF
--- a/roles/mythtv/tasks/homebrew_macosx.yml
+++ b/roles/mythtv/tasks/homebrew_macosx.yml
@@ -27,7 +27,7 @@
   set_fact:
     cpanm_active: true
 
-- name: homebrew_macosx | Set database_version as {{ database_version }}
+- name: homebrew_macosx | Set database_version to mariadb if undefined
   set_fact:
     database_version: mariadb
   when: database_version is undefined

--- a/roles/mythtv/tasks/macports_macosx.yml
+++ b/roles/mythtv/tasks/macports_macosx.yml
@@ -24,7 +24,7 @@
   set_fact:
     venv_active: true
 
-- name: macports_macosx | Set database_version as {{ database_version }}
+- name: macports_macosx | Set database_version to mysql8 if undefined
   set_fact:
     database_version: mysql8
   when: database_version is undefined


### PR DESCRIPTION
  fix error where database_version is used in the status message
  before being defined.