### PR TITLE
macOS: fix macports qt5/6 parsing logic

### DIFF
--- a/roles/mythtv/tasks/macports_macosx.yml
+++ b/roles/mythtv/tasks/macports_macosx.yml
@@ -67,7 +67,7 @@
 - name: macports_macosx | Set qt_version as qt6
   set_fact:
     qt_version: qt6
-  when: qt5 | default(true) | bool
+  when: qt6 | default(false) | bool
 
 # get the python version specified by user in ansible_python_interpreter or defaulted by the interpreter
 - name: macports_macosx | Gather specific Python facts


### PR DESCRIPTION
Fix a bug where macports installs qt5 but attempts to incorrectly install qt6-mysql-plugin.