### PR TITLE
perl: remove mirror

### DIFF
--- a/roles/perl/tasks/cpanm_install.yml
+++ b/roles/perl/tasks/cpanm_install.yml
@@ -3,12 +3,12 @@
 # install perl modules with ansible's cpanm capabiltiy
 #
 # --mirror 'http://cpan.cpantesters.org/'
+# --mirror 'https://metacpan.org/'
 ---
 
 - name: 'cpanm_install | Install perl modules'
   become: false
   command: cpanm
-    --mirror 'https://metacpan.org/'
     --force
     {{ perl_modules | join(' ') }}
   ignore_errors: yes


### PR DESCRIPTION
  The cpanm default download site is working agin. This renders
  setting the mirror as no longer necessary.